### PR TITLE
Remove unstable label from up and down

### DIFF
--- a/ksail
+++ b/ksail
@@ -15,8 +15,8 @@ function main_run_help_no_arg() {
   echo
   echo "Commands:"
   echo "  install     install dependencies"
-  echo "  up          create cluster (⚠️ unstable)"
-  echo "  down        destroy cluster (⚠️ unstable)"
+  echo "  up          create cluster"
+  echo "  down        destroy cluster"
   echo "  update      update cluster (⚠️ unstable)"
   echo "  validate    validate manifest files (⚠️ unstable)"
   echo "  verify      verify cluster reconciliation (⚠️ unstable)"


### PR DESCRIPTION
This pull request removes the "unstable" label from the "up" and "down" commands in the script. The commands are now stable and can be used without issues.

They are however a bit lackluster in functionality.

The up command currently does not validate manifests or verify reconciliation to the degree I would like.