### PR TITLE
Update help to better reflect arguments

### DIFF
--- a/ksail
+++ b/ksail
@@ -47,8 +47,8 @@ function main_run_help_up_arg() {
   echo
   echo "Flags:"
   echo -e "  -n   name of the cluster (${GREEN}ksail${WHITE})"
-  echo -e "  -m   path to the manifests files root directory (${GREEN}./k8s${WHITE})"
-  echo -e "  -f   path to the flux kustomization manifests (${GREEN}./clusters/${PURPLE}<cluster-name>${GREEN}/flux${WHITE})"
+  echo -e "  -m   path to the manifests files that should be pushed to a local OCI registry (${GREEN}./k8s${WHITE})"
+  echo -e "  -f   path to the flux kustomization files within the OCI registry (${GREEN}./clusters/${PURPLE}<cluster-name>${GREEN}/flux${WHITE})"
   echo
   echo "ℹ️ Notes:"
   echo -e "  - Backends may have additional flags. Run '${BLUE}ksail up ${PURPLE}<backend>${BLUE} -h${WHITE}' for more information."
@@ -60,8 +60,8 @@ function main_run_help_up_k3d_arg() {
   echo
   echo "Flags:"
   echo -e "  -n   name of the cluster (${GREEN}ksail${WHITE})"
-  echo -e "  -m   path to the manifests files root directory (${GREEN}./k8s${WHITE})"
-  echo -e "  -f   path to the flux kustomization manifests (${GREEN}./clusters/${PURPLE}<cluster-name>${GREEN}/flux${WHITE})"
+  echo -e "  -m   path to the manifests files that should be pushed to a local OCI registry (${GREEN}./k8s${WHITE})"
+  echo -e "  -f   path to the flux kustomization files within the OCI registry (${GREEN}./clusters/${PURPLE}<cluster-name>${GREEN}/flux${WHITE})"
   echo -e "  -c   path to the k3d cluster config file (${GREEN}./${PURPLE}<cluster-name>${GREEN}-k3d-config.yaml${WHITE})"
 }
 
@@ -71,8 +71,8 @@ function main_run_help_up_talos_arg() {
   echo
   echo "Flags:"
   echo -e "  -n   name of the cluster (${GREEN}ksail${WHITE})"
-  echo -e "  -m   path to the manifests files root directory (${GREEN}./k8s${WHITE})"
-  echo -e "  -f   path to the flux kustomization manifests (${GREEN}./clusters/${PURPLE}<cluster-name>${GREEN}/flux${WHITE})"
+  echo -e "  -m   path to the manifests files that should be pushed to a local OCI registry (${GREEN}./k8s${WHITE})"
+  echo -e "  -f   path to the flux kustomization files within the OCI registry (${GREEN}./clusters/${PURPLE}<cluster-name>${GREEN}/flux${WHITE})"
 }
 
 function main_run_help_down_arg() {


### PR DESCRIPTION
This pull request updates the help text to provide more accurate descriptions of the arguments responsible for specifying the paths to the manifests files and the flux kustomization files within the OCI registry.