### PR TITLE
Update cron schedule in assets.yaml

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -2,7 +2,7 @@ name: Assets
 
 on:
   schedule:
-    - cron: "59 23 * * 5"
+    - cron: "59 23 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Update the cron schedule in the assets.yaml file to run every day instead of just on Fridays.