### PR TITLE
Remove unnecessary dotnet publish commands

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,9 +27,6 @@ jobs:
 
           dotnet publish -c Release -r linux-arm64 src/KSail/KSail.csproj
           mv src/KSail/bin/Release/net8.0/linux-arm64/publish/ksail ksail-${{ github.ref_name}}-linux-arm64
-
-          dotnet publish -c Release -r linux-arm src/KSail/KSail.csproj
-          mv src/KSail/bin/Release/net8.0/linux-arm/publish/ksail ksail-${{ github.ref_name}}-linux-arm
       - name: 🎉 Release
         uses: softprops/action-gh-release@v1
         with:
@@ -38,4 +35,3 @@ jobs:
             ksail-${{ github.ref_name}}-osx-arm64
             ksail-${{ github.ref_name}}-linux-x64
             ksail-${{ github.ref_name}}-linux-arm64
-            ksail-${{ github.ref_name}}-linux-arm


### PR DESCRIPTION
This pull request removes unnecessary dotnet publish commands from the publish.yaml file. The commands for publishing to linux-arm  have been removed.