### PR TITLE
Fix dotnet publish command for osx-arm64

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
           dotnet publish -c Release -r osx-x64 src/KSail/KSail.csproj
           mv src/KSail/bin/Release/net8.0/osx-x64/publish/ksail ksail-${{ github.ref_name}}-osx-x64
 
-          dotnet publish -c Release -r oxs-arm64 src/KSail/KSail.csproj
+          dotnet publish -c Release -r osx-arm64 src/KSail/KSail.csproj
           mv src/KSail/bin/Release/net8.0/osx-arm64/publish/ksail ksail-${{ github.ref_name}}-osx-arm64
 
           dotnet publish -c Release -r linux-x64 src/KSail/KSail.csproj


### PR DESCRIPTION
This pull request fixes a typo in the dotnet publish command for osx-arm64, correcting the platform name from "oxs-arm64" to "osx-arm64". This ensures that the correct binary is generated for the osx-arm64 platform.