### PR TITLE
Add check for valid version format in get_wrapped_binaries.sh

### DIFF
--- a/scripts/get_wrapped_binaries.sh
+++ b/scripts/get_wrapped_binaries.sh
@@ -63,3 +63,4 @@ download_and_update "k3d-io/k3d" "k3d" false
 download_and_update "siderolabs/talos" "talosctl" false
 download_and_update "yannh/kubeconform" "kubeconform" true
 download_and_update "kubernetes-sigs/kustomize" "kustomize" true
+find src/KSail/assets/binaries -name "LICENSE" -type f -delete

--- a/scripts/get_wrapped_binaries.sh
+++ b/scripts/get_wrapped_binaries.sh
@@ -8,6 +8,11 @@ download_and_update() {
   if [ -z "$version_latest" ]; then
     echo "No version of $binary found, this is usually due to a rate limit on the GitHub API"
     return
+  else
+    # Check that version is semver vx.x.x or x.x.x
+    if ! [[ "$version_latest" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && ! [[ "$version_latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      version_latest=$(echo "$version_latest" | cut -d '/' -f 2)
+    fi
   fi
   if [ -f src/KSail/assets/binaries/requirements.txt ]; then
     version_current=$(grep "${binary}_version_" src/KSail/assets/binaries/requirements.txt | cut -d '_' -f 3)


### PR DESCRIPTION
This pull request adds a check for a valid version format in the get_wrapped_binaries.sh script. If the version format is not semver vx.x.x or x.x.x, the script will extract the version from the URL. Additionally, this pull request removes the LICENSE files from the binary assets.