### PR TITLE
Update publish script to include version number

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,16 +20,17 @@ jobs:
           dotnet-version: "8.x.x"
       - name: 📦 Publish
         run: |
-          dotnet publish -c Release -r osx-x64 src/KSail/KSail.csproj
+          version=$(echo "${{ github.ref_name }}" | sed -e 's/v//')
+          dotnet publish -c Release -r osx-x64 src/KSail/KSail.csproj /p:Version=$version
           mv src/KSail/bin/Release/net8.0/osx-x64/publish/ksail ksail-osx-x64
 
-          dotnet publish -c Release -r osx-arm64 src/KSail/KSail.csproj
+          dotnet publish -c Release -r osx-arm64 src/KSail/KSail.csproj /p:Version=$version
           mv src/KSail/bin/Release/net8.0/osx-arm64/publish/ksail ksail-osx-arm64
 
-          dotnet publish -c Release -r linux-x64 src/KSail/KSail.csproj
+          dotnet publish -c Release -r linux-x64 src/KSail/KSail.csproj /p:Version=$version
           mv src/KSail/bin/Release/net8.0/linux-x64/publish/ksail ksail-linux-x64
 
-          dotnet publish -c Release -r linux-arm64 src/KSail/KSail.csproj
+          dotnet publish -c Release -r linux-arm64 src/KSail/KSail.csproj /p:Version=$version
           mv src/KSail/bin/Release/net8.0/linux-arm64/publish/ksail ksail-linux-arm64
 
           tar -czf ksail.tar.gz ksail-osx-x64 ksail-osx-arm64 ksail-linux-x64 ksail-linux-arm64

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -7,7 +7,6 @@
     <SelfContained>true</SelfContained>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
-    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates the publish script to include the version number in the dotnet publish command. This ensures that the published artifacts have the correct version number.