### PR TITLE
Add possibility to validate all clusters

### DIFF
--- a/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
+++ b/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
@@ -13,12 +13,6 @@ class KSailLintCommandHandler()
   {
     Console.WriteLine("🧹 Linting manifest files...");
 
-    if (string.IsNullOrEmpty(name))
-    {
-      Console.WriteLine("✕ Name of the cluster is required...");
-      Environment.Exit(1);
-    }
-
     Console.WriteLine("► Downloading Flux OpenAPI schemas...");
     const string url = "https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz";
     var directoryInfo = Directory.CreateDirectory("/tmp/flux-crd-schemas/master-standalone-strict");
@@ -29,7 +23,17 @@ class KSailLintCommandHandler()
     }
 
     ValidateYaml(manifestsPath);
-    await ValidateKustomizationsAsync(name, manifestsPath);
+    if (string.IsNullOrEmpty(name))
+    {
+      foreach (string cluster in Directory.GetDirectories($"{manifestsPath}/clusters"))
+      {
+        await ValidateKustomizationsAsync(cluster, manifestsPath);
+      }
+    }
+    else
+    {
+      await ValidateKustomizationsAsync(name, manifestsPath);
+    }
     Console.WriteLine("");
   }
 

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -8,7 +8,7 @@ namespace KSail.Commands.Update;
 
 sealed class KSailUpdateCommand : Command
 {
-  readonly NameArgument nameArgument = new();
+  readonly NameArgument nameArgument = new() { Arity = ArgumentArity.ZeroOrOne };
   readonly ManifestsOption manifestsOption = new() { IsRequired = true };
   readonly NoLintOption noLintOption = new();
   internal KSailUpdateCommand() : base(


### PR DESCRIPTION
This pull request adds the possibility to validate all clusters in the manifests directory. Previously, only a single cluster could be validated at a time. Now, if no cluster name is provided, the validation process will iterate through all clusters in the directory and validate them individually. This improves the convenience of the validation process.