### PR TITLE
Refactor cluster validation in KSailLintCommandHandler

### DIFF
--- a/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
+++ b/src/KSail/Commands/Lint/Handlers/KSailLintCommandHandler.cs
@@ -25,9 +25,9 @@ class KSailLintCommandHandler()
     ValidateYaml(manifestsPath);
     if (string.IsNullOrEmpty(name))
     {
-      foreach (string cluster in Directory.GetDirectories($"{manifestsPath}/clusters"))
+      foreach (string clusterPath in Directory.GetDirectories($"{manifestsPath}/clusters"))
       {
-        await ValidateKustomizationsAsync(cluster, manifestsPath);
+        await ValidateKustomizationsAsync(clusterPath, manifestsPath);
       }
     }
     else
@@ -70,18 +70,17 @@ class KSailLintCommandHandler()
     }
   }
 
-  static async Task ValidateKustomizationsAsync(string name, string manifestsPath)
+  static async Task ValidateKustomizationsAsync(string clusterPath, string manifestsPath)
   {
     string[] kubeconformFlags = ["-skip=Secret"];
     string[] kubeconformConfig = ["-strict", "-ignore-missing-schemas", "-schema-location", "default", "-schema-location", "/tmp/flux-crd-schemas", "-verbose"];
 
-    string clusterPath = $"{manifestsPath}/clusters/{name}";
     if (!Directory.Exists(clusterPath))
     {
-      Console.WriteLine($"🚨 Cluster '{name}' not found in path '{clusterPath}'...");
+      Console.WriteLine($"🚨 Cluster '{clusterPath}' not found...");
       Environment.Exit(1);
     }
-    Console.WriteLine($"► Validating cluster '{name}' with Kubeconform...");
+    Console.WriteLine($"► Validating cluster '{clusterPath}' with Kubeconform...");
     foreach (string manifest in Directory.GetFiles(clusterPath, "*.yaml", SearchOption.AllDirectories))
     {
       KubeconformCLIWrapper.Run(kubeconformFlags, kubeconformConfig, manifest);

--- a/src/KSail/Commands/Lint/KSailLintCommand.cs
+++ b/src/KSail/Commands/Lint/KSailLintCommand.cs
@@ -7,10 +7,10 @@ namespace KSail.Commands.Lint;
 
 sealed class KSailLintCommand : Command
 {
-  readonly NameArgument nameArgument = new();
+  readonly NameArgument nameArgument = new() { Arity = ArgumentArity.ExactlyOne };
   readonly ManifestsOption manifestsOption = new() { IsRequired = true };
   internal KSailLintCommand() : base(
-   "lint", "Lint manifest files"
+    "lint", "Lint manifest files"
   )
   {
     AddArgument(nameArgument);

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -8,7 +8,7 @@ namespace KSail.Commands.Update;
 
 sealed class KSailUpdateCommand : Command
 {
-  readonly NameArgument nameArgument = new() { Arity = ArgumentArity.ZeroOrOne };
+  readonly NameArgument nameArgument = new() { Arity = ArgumentArity.ExactlyOne };
   readonly ManifestsOption manifestsOption = new() { IsRequired = true };
   readonly NoLintOption noLintOption = new();
   internal KSailUpdateCommand() : base(


### PR DESCRIPTION
This pull request refactors the cluster validation in the KSailLintCommandHandler class. It updates the method ValidateKustomizationsAsync to use the clusterPath parameter instead of the name parameter. This change ensures that the correct cluster path is used when validating kustomizations.