### PR TITLE
Enable assignees from code owners in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "assigneesFromCodeOwners": true,
   "flux": {
     "fileMatch": [
       "^k8s/.+\\.ya?ml$"


### PR DESCRIPTION
This pull request enables the use of assignees from code owners in the renovate.json file. This allows for better assignment of code reviews and ensures that the appropriate team members are notified when changes are made.