### PR TITLE
Refactor DockerProvisioner to use default DockerClient configuration

### DIFF
--- a/src/KSail/Provisioners/ContainerEngine/DockerProvisioner.cs
+++ b/src/KSail/Provisioners/ContainerEngine/DockerProvisioner.cs
@@ -6,9 +6,7 @@ namespace KSail.Provisioners.ContainerEngine;
 
 sealed class DockerProvisioner : IContainerEngineProvisioner
 {
-  readonly DockerClient _dockerClient = new DockerClientConfiguration(
-    new Uri("unix:///var/run/docker.sock")
-  ).CreateClient();
+  readonly DockerClient _dockerClient = new DockerClientConfiguration().CreateClient();
 
   public async Task<int> CheckReadyAsync(CancellationToken token)
   {


### PR DESCRIPTION
This pull request refactors the DockerProvisioner class to use the default DockerClient configuration instead of specifying the Unix socket path explicitly. This simplifies the code and ensures compatibility with different Docker setups.