### PR TITLE
Remove unnecessary console output in KSailCheckCommandHandler

### DIFF
--- a/src/KSail/Commands/Check/Handlers/KSailCheckCommandHandler.cs
+++ b/src/KSail/Commands/Check/Handlers/KSailCheckCommandHandler.cs
@@ -11,6 +11,7 @@ class KSailCheckCommandHandler()
   readonly HashSet<string> _successfulKustomizations = [];
   readonly Stopwatch _stopwatch = Stopwatch.StartNew();
   readonly Stopwatch _stopwatchTotal = Stopwatch.StartNew();
+  string _lastPrintedMessage = "";
 
   internal async Task<int> HandleAsync(string context, int timeout, CancellationToken token, string? kubeconfig = null)
   {
@@ -77,7 +78,7 @@ class KSailCheckCommandHandler()
       {
         HandleReadyStatus(kustomizationName);
       }
-      else
+      else if (!waitingKustomizations.Contains(kustomizationName)) // Check if kustomization is already being waited for
       {
         HandleOtherStatus(kustomizationName);
       }
@@ -107,7 +108,12 @@ class KSailCheckCommandHandler()
     var timeElapsed = _stopwatch.Elapsed;
     int minutes = timeElapsed.Minutes;
     int seconds = timeElapsed.Seconds;
-    Console.WriteLine($"◎ Waiting for kustomization '{kustomizationName}' to become ready ({minutes}m {seconds}s)");
+    string message = $"◎ Waiting for kustomization '{kustomizationName}' to become ready ({minutes}m {seconds}s)";
+    if (message != _lastPrintedMessage)
+    {
+      Console.WriteLine(message);
+      _lastPrintedMessage = message;
+    }
   }
 
   void HandleReadyStatus(string kustomizationName)

--- a/src/KSail/Commands/Check/Handlers/KSailCheckCommandHandler.cs
+++ b/src/KSail/Commands/Check/Handlers/KSailCheckCommandHandler.cs
@@ -78,7 +78,7 @@ class KSailCheckCommandHandler()
       {
         HandleReadyStatus(kustomizationName);
       }
-      else if (!waitingKustomizations.Contains(kustomizationName)) // Check if kustomization is already being waited for
+      else
       {
         HandleOtherStatus(kustomizationName);
       }

--- a/src/KSail/Commands/Init/Generators/InitFilesGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/InitFilesGenerator.cs
@@ -72,11 +72,6 @@ class InitFilesGenerator : IDisposable
 
   async Task GeneratePostBuildVariables(string clusterDirectory, string clusterName)
   {
-    await _kubernetesGenerator.GenerateKustomizationAsync(
-      Path.Combine(clusterDirectory, "variables/kustomization.yaml"),
-      ["variables.yaml", "variables-sensitive.sops.yaml"],
-      "flux-system"
-    );
     await KubernetesGenerator.GenerateConfigMapAsync(Path.Combine(clusterDirectory, "variables/variables.yaml"), clusterName);
     await KubernetesGenerator.GenerateSecretAsync(Path.Combine(clusterDirectory, "variables/variables-sensitive.sops.yaml"));
   }
@@ -108,7 +103,8 @@ class InitFilesGenerator : IDisposable
       new FluxKustomizationContent
       {
         Name = "selfsigned-cluster-issuer",
-        Path = "cert-manager/cluster-issuers/selfsigned"
+        Path = "cert-manager/cluster-issuers/selfsigned",
+        DependsOn = ["cert-manager"]
       }
     ]);
 

--- a/src/KSail/Commands/Init/Generators/InitFilesGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/InitFilesGenerator.cs
@@ -40,6 +40,8 @@ class InitFilesGenerator : IDisposable
           {
             Name = "repositories",
             Path = "manifests/repositories",
+            Decryption = null,
+            PostBuild = null
           }
     ]);
   }
@@ -52,6 +54,7 @@ class InitFilesGenerator : IDisposable
           {
             Name = "variables",
             Path = $"clusters/{clusterName}/variables",
+            PostBuild = null,
             DependsOn = ["repositories"]
           }
     ]);
@@ -121,7 +124,11 @@ class InitFilesGenerator : IDisposable
       new FluxKustomizationContent
       {
         Name = "cert-manager",
-        Path = "cert-manager"
+        Path = "cert-manager",
+        SourceRef = new(){
+          Kind = "OCIRepository",
+          Name = "oci-artifacts"
+        }
       }
     ]);
     await _kubernetesGenerator.GenerateFluxKustomizationAsync(Path.Combine(manifestsDirectory, "infrastructure/cert-manager/selfsigned-cluster-issuer.yaml"),
@@ -130,6 +137,10 @@ class InitFilesGenerator : IDisposable
       {
         Name = "selfsigned-cluster-issuer",
         Path = "cert-manager/cluster-issuers/selfsigned",
+        SourceRef = new(){
+          Kind = "OCIRepository",
+          Name = "oci-artifacts"
+        },
         DependsOn = ["cert-manager"]
       }
     ]);
@@ -145,7 +156,11 @@ class InitFilesGenerator : IDisposable
         new FluxKustomizationContent
         {
           Name = "traefik",
-          Path = "traefik"
+          Path = "traefik",
+          SourceRef = new(){
+            Kind = "OCIRepository",
+            Name = "oci-artifacts"
+          }
         }
       ]);
   }

--- a/src/KSail/Commands/Init/Generators/KubernetesGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/KubernetesGenerator.cs
@@ -86,8 +86,14 @@ class KubernetesGenerator
       kind: Secret
       metadata:
         name: variables-sensitive
+        namespace: flux-system
       stringData: {}
       """;
+    var directoryPath = Path.GetDirectoryName(filePath);
+    if (!Directory.Exists(directoryPath))
+    {
+      Directory.CreateDirectory(directoryPath);
+    }
     var variablesSensitiveYamlFile = File.Create(filePath) ?? throw new InvalidOperationException($"🚨 Could not create '{filePath}'.");
     await variablesSensitiveYamlFile.WriteAsync(Encoding.UTF8.GetBytes(variablesSensitiveYamlContent));
     await variablesSensitiveYamlFile.FlushAsync();
@@ -106,12 +112,19 @@ class KubernetesGenerator
       kind: ConfigMap
       metadata:
         name: variables
+        namespace: flux-system
       data:
         cluster_domain: {clusterName}.local
         cluster_issuer_name: selfsigned-cluster-issuer
       """;
+    var directoryPath = Path.GetDirectoryName(filePath);
+    if (!Directory.Exists(directoryPath))
+    {
+      Directory.CreateDirectory(directoryPath);
+    }
     var variablesYamlFile = File.Create(filePath) ?? throw new InvalidOperationException($"🚨 Could not create the variables.yaml file at {filePath}.");
     await variablesYamlFile.WriteAsync(Encoding.UTF8.GetBytes(variablesYamlContent));
     await variablesYamlFile.FlushAsync();
   }
 }
+

--- a/src/KSail/Commands/Init/Generators/KubernetesGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/KubernetesGenerator.cs
@@ -50,6 +50,23 @@ class KubernetesGenerator
     }
   }
 
+  internal async Task GenerateOCIRepositoryAsync(string filePath, OCIRepository ociRepository)
+  {
+    if (!File.Exists(filePath))
+    {
+      Console.WriteLine($"✚ Generating OCI Repository '{filePath}'");
+      await _generator.GenerateAsync(
+          filePath,
+          $"{AppDomain.CurrentDomain.BaseDirectory}/assets/templates/kubernetes/oci-repository.sbn",
+          ociRepository
+      );
+    }
+    else
+    {
+      Console.WriteLine($"✓ OCI Repository '{filePath}' already exists");
+    }
+  }
+
   internal async Task GenerateKustomizationAsync(string filePath, List<string> resources, string @namespace = "")
   {
     if (!File.Exists(filePath))
@@ -89,10 +106,10 @@ class KubernetesGenerator
         namespace: flux-system
       stringData: {}
       """;
-    var directoryPath = Path.GetDirectoryName(filePath);
+    string? directoryPath = Path.GetDirectoryName(filePath) ?? throw new InvalidOperationException($"🚨 Could not get the directory path of '{filePath}'.");
     if (!Directory.Exists(directoryPath))
     {
-      Directory.CreateDirectory(directoryPath);
+      _ = Directory.CreateDirectory(directoryPath);
     }
     var variablesSensitiveYamlFile = File.Create(filePath) ?? throw new InvalidOperationException($"🚨 Could not create '{filePath}'.");
     await variablesSensitiveYamlFile.WriteAsync(Encoding.UTF8.GetBytes(variablesSensitiveYamlContent));
@@ -117,14 +134,13 @@ class KubernetesGenerator
         cluster_domain: {clusterName}.local
         cluster_issuer_name: selfsigned-cluster-issuer
       """;
-    var directoryPath = Path.GetDirectoryName(filePath);
+    string? directoryPath = Path.GetDirectoryName(filePath) ?? throw new InvalidOperationException($"🚨 Could not get the directory path of '{filePath}'.");
     if (!Directory.Exists(directoryPath))
     {
-      Directory.CreateDirectory(directoryPath);
+      _ = Directory.CreateDirectory(directoryPath);
     }
     var variablesYamlFile = File.Create(filePath) ?? throw new InvalidOperationException($"🚨 Could not create the variables.yaml file at {filePath}.");
     await variablesYamlFile.WriteAsync(Encoding.UTF8.GetBytes(variablesYamlContent));
     await variablesYamlFile.FlushAsync();
   }
 }
-

--- a/src/KSail/Models/Kubernetes/FluxKustomization/FluxKustomizationContent.cs
+++ b/src/KSail/Models/Kubernetes/FluxKustomization/FluxKustomizationContent.cs
@@ -4,7 +4,7 @@ class FluxKustomizationContent
 {
   public required string Name { get; set; }
   public string Namespace { get; set; } = "flux-system";
-  public string Interval { get; set; } = "1m";
+  public string Interval { get; set; } = "30s";
   public List<string> DependsOn { get; set; } = [];
   public FluxKustomizationSourceRef SourceRef { get; set; } = new FluxKustomizationSourceRef
   {

--- a/src/KSail/Models/Kubernetes/FluxKustomization/FluxKustomizationContent.cs
+++ b/src/KSail/Models/Kubernetes/FluxKustomization/FluxKustomizationContent.cs
@@ -14,7 +14,7 @@ class FluxKustomizationContent
   public required string Path { get; set; }
   public bool Prune { get; set; } = true;
   public bool Wait { get; set; } = true;
-  public FluxKustomizationDecryption Decryption { get; set; } = new FluxKustomizationDecryption
+  public FluxKustomizationDecryption? Decryption { get; set; } = new FluxKustomizationDecryption
   {
     Provider = FluxKustomizationDecryptionProvider.SOPS,
     SecretRef = new FluxKustomizationDecryptionSecretRef
@@ -22,7 +22,7 @@ class FluxKustomizationContent
       Name = "sops-age"
     }
   };
-  public FluxKustomizationPostBuild PostBuild { get; set; } = new FluxKustomizationPostBuild
+  public FluxKustomizationPostBuild? PostBuild { get; set; } = new FluxKustomizationPostBuild
   {
     SubstituteFrom =
     [

--- a/src/KSail/Models/Kubernetes/OCIRepository.cs
+++ b/src/KSail/Models/Kubernetes/OCIRepository.cs
@@ -1,0 +1,10 @@
+namespace KSail.Models.Kubernetes;
+
+class OCIRepository
+{
+  public required string Name { get; set; }
+  public required string Namespace { get; set; }
+  public string Interval { get; set; } = "1m";
+  public required string Url { get; set; }
+  public required string Tag { get; set; }
+}

--- a/src/KSail/assets/templates/kubernetes/flux-kustomization.sbn
+++ b/src/KSail/assets/templates/kubernetes/flux-kustomization.sbn
@@ -16,16 +16,20 @@ spec:
   path: {{ c.path }}
   prune: {{ c.prune }}
   wait: {{ c.wait }}
+  {{~ if c.decryption ~}}
   decryption:
     provider: {{ c.decryption.provider | string.downcase }}
     secretRef:
       name: {{ c.decryption.secret_ref.name }}
+  {{~ end ~}}
+  {{~ if c.post_build ~}}
   postBuild:
     substituteFrom: {{ if c.post_build.substitute_from == empty }}[]{{ end }}
     {{~ for sub in c.post_build.substitute_from ~}}
       - kind: {{ sub.kind }}
         name: {{ sub.name }}
     {{~ end ~}}
+  {{~ end ~}}
 {{~ if !for.last ~}}
 ---
 {{~ end ~}}

--- a/src/KSail/assets/templates/kubernetes/oci-repository.sbn
+++ b/src/KSail/assets/templates/kubernetes/oci-repository.sbn
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: {{ name }}
+  namespace: {{ namespace }}
+spec:
+  interval: {{ interval }}
+  url: {{ url }}
+  ref:
+    tag: {{ tag }}


### PR DESCRIPTION
This pull request removes unnecessary console output in the `KSailCheckCommandHandler` class. Previously, the code was printing a message for every kustomization being waited for, even if the message was the same as the previous one. This PR introduces a check to only print the message if it is different from the last printed message. This improves the readability of the console output and reduces unnecessary noise.

Closes #228