### PR TITLE
Improve cluster start/stop commands with enhanced output and error handling

### DIFF
--- a/src/KSail/Commands/Start/KSailStartCommand.cs
+++ b/src/KSail/Commands/Start/KSailStartCommand.cs
@@ -29,7 +29,7 @@ sealed class KSailStartCommand : Command
         }
         else
         {
-          throw new KSailException("❌ Cluster could not be started");
+          throw new KSailException("Cluster could not be started");
         }
       }
       catch (OperationCanceledException ex)

--- a/src/KSail/Commands/Start/KSailStartCommand.cs
+++ b/src/KSail/Commands/Start/KSailStartCommand.cs
@@ -20,19 +20,24 @@ sealed class KSailStartCommand : Command
         var config = await KSailClusterConfigLoader.LoadAsync(name: context.ParseResult.GetValueForOption(_nameOption)).ConfigureAwait(false);
         config.UpdateConfig("Metadata.Name", context.ParseResult.GetValueForOption(_nameOption));
 
-        Console.WriteLine("🟢 Starting cluster");
+        Console.WriteLine($"🟢 Starting cluster '{config.Spec.Project.Distribution.ToString().ToLower(System.Globalization.CultureInfo.CurrentCulture)}-{config.Metadata.Name}'");
         var handler = new KSailStartCommandHandler(config);
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
         if (context.ExitCode == 0)
         {
-          Console.WriteLine("🚀 Cluster started");
+          Console.WriteLine("✔ Cluster started");
         }
         else
         {
-          Console.WriteLine("❌ Cluster could not be started");
+          throw new KSailException("❌ Cluster could not be started");
         }
       }
       catch (OperationCanceledException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+      catch (KSailException ex)
       {
         ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;

--- a/src/KSail/Commands/Stop/KSailStopCommand.cs
+++ b/src/KSail/Commands/Stop/KSailStopCommand.cs
@@ -29,7 +29,7 @@ sealed class KSailStopCommand : Command
         }
         else
         {
-          throw new KSailException("❌ Cluster could not be stopped");
+          throw new KSailException("Cluster could not be stopped");
         }
       }
       catch (OperationCanceledException)

--- a/src/KSail/Commands/Stop/KSailStopCommand.cs
+++ b/src/KSail/Commands/Stop/KSailStopCommand.cs
@@ -21,19 +21,24 @@ sealed class KSailStopCommand : Command
       var handler = new KSailStopCommandHandler(config);
       try
       {
-        Console.WriteLine("🛑 Stopping cluster");
+        Console.WriteLine($"🛑 Stopping cluster '{config.Spec.Project.Distribution.ToString().ToLower(System.Globalization.CultureInfo.CurrentCulture)}-{config.Metadata.Name}'");
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
         if (context.ExitCode == 0)
         {
-          Console.WriteLine("👋 Cluster stopped");
+          Console.WriteLine("✔ Cluster stopped");
         }
         else
         {
-          Console.WriteLine("❌ Cluster could not be stopped");
+          throw new KSailException("❌ Cluster could not be stopped");
         }
       }
       catch (OperationCanceledException)
       {
+        context.ExitCode = 1;
+      }
+      catch (KSailException ex)
+      {
+        ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;
       }
     });


### PR DESCRIPTION
Streamline the output messages for starting and stopping clusters, and improve exception handling for clearer error reporting.