### PR TITLE
Remove K3dOptions from DistributionConfigFileGenerator

### DIFF
--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -70,21 +70,6 @@ class DistributionConfigFileGenerator
       {
         Name = config.Metadata.Name
       },
-      Options = new K3dOptions
-      {
-        K3s = new K3dOptionsK3s
-        {
-          ExtraArgs = [
-            new K3dOptionsK3sExtraArg
-            {
-              Arg = "--disable=traefik",
-              NodeFilters = [
-                "server:*"
-              ]
-            }
-          ]
-        }
-      },
       Registries = new K3dRegistries
       {
         Config = $"""

--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -1,8 +1,6 @@
 using System.Text;
 using Devantler.KubernetesGenerator.K3d;
 using Devantler.KubernetesGenerator.K3d.Models;
-using Devantler.KubernetesGenerator.K3d.Models.Options;
-using Devantler.KubernetesGenerator.K3d.Models.Options.K3s;
 using Devantler.KubernetesGenerator.K3d.Models.Registries;
 using Devantler.KubernetesGenerator.Kind;
 using Devantler.KubernetesGenerator.Kind.Models;


### PR DESCRIPTION
Eliminate the K3dOptions configuration to streamline the generation of K3D config files, reverting to default settings.