### PR TITLE
Add YamlException handling for improved error output

### DIFF
--- a/src/KSail/Commands/Debug/KSailDebugCommand.cs
+++ b/src/KSail/Commands/Debug/KSailDebugCommand.cs
@@ -3,6 +3,7 @@ using KSail.Commands.Debug.Handlers;
 using KSail.Commands.Debug.Options;
 using KSail.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.Debug;
 
@@ -28,6 +29,11 @@ sealed class KSailDebugCommand : Command
         var handler = new KSailDebugCommandHandler(config);
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
         Console.WriteLine();
+      }
+      catch (YamlException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
       }
       catch (OperationCanceledException ex)
       {

--- a/src/KSail/Commands/Down/KSailDownCommand.cs
+++ b/src/KSail/Commands/Down/KSailDownCommand.cs
@@ -5,6 +5,7 @@ using KSail.Commands.Down.Handlers;
 using KSail.Commands.Down.Options;
 using KSail.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.Down;
 
@@ -33,7 +34,7 @@ sealed class KSailDownCommand : Command
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
         Console.WriteLine();
       }
-      catch (OperationCanceledException ex)
+      catch (YamlException ex)
       {
         ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;
@@ -44,6 +45,11 @@ sealed class KSailDownCommand : Command
         context.ExitCode = 1;
       }
       catch (K3dException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+      catch (OperationCanceledException ex)
       {
         ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;

--- a/src/KSail/Commands/Init/KSailInitCommand.cs
+++ b/src/KSail/Commands/Init/KSailInitCommand.cs
@@ -4,6 +4,7 @@ using KSail.Commands.Init.Options;
 using KSail.Models.Project;
 using KSail.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.Init;
 
@@ -42,6 +43,11 @@ sealed class KSailInitCommand : Command
         Console.WriteLine($"📁 Initializing new cluster '{config.Metadata.Name}' in '{config.Spec.CLI.InitOptions.OutputDirectory}' with the '{config.Spec.CLI.InitOptions.Template}' template.");
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
         Console.WriteLine();
+      }
+      catch (YamlException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
       }
       catch (OperationCanceledException ex)
       {

--- a/src/KSail/Commands/Lint/KSailLintCommand.cs
+++ b/src/KSail/Commands/Lint/KSailLintCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using KSail.Commands.Lint.Handlers;
 using KSail.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.Lint;
 
@@ -28,6 +29,11 @@ sealed class KSailLintCommand : Command
         var handler = new KSailLintCommandHandler();
         context.ExitCode = await handler.HandleAsync(config, context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
         Console.WriteLine();
+      }
+      catch (YamlException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
       }
       catch (OperationCanceledException ex)
       {

--- a/src/KSail/Commands/List/KsailListCommand.cs
+++ b/src/KSail/Commands/List/KsailListCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using KSail.Commands.List.Handlers;
 using KSail.Commands.List.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.List;
 
@@ -23,6 +24,11 @@ sealed class KSailListCommand : Command
         Console.WriteLine("📋 Listing clusters");
         _ = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false);
         Console.WriteLine();
+      }
+      catch (YamlException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
       }
       catch (OperationCanceledException ex)
       {

--- a/src/KSail/Commands/SOPS/Commands/KSailSopsListCommand.cs
+++ b/src/KSail/Commands/SOPS/Commands/KSailSopsListCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using KSail.Commands.SOPS.Handlers;
 using KSail.Commands.SOPS.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.SOPS.Commands;
 
@@ -28,6 +29,11 @@ sealed class KSailSOPSListCommand : Command
         Console.WriteLine("🔑 Listing keys");
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
         Console.WriteLine();
+      }
+      catch (YamlException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
       }
       catch (OperationCanceledException ex)
       {

--- a/src/KSail/Commands/Start/KSailStartCommand.cs
+++ b/src/KSail/Commands/Start/KSailStartCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using KSail.Commands.Start.Handlers;
 using KSail.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.Start;
 
@@ -32,12 +33,17 @@ sealed class KSailStartCommand : Command
           throw new KSailException("Cluster could not be started");
         }
       }
-      catch (OperationCanceledException ex)
+      catch (YamlException ex)
       {
         ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;
       }
       catch (KSailException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+      catch (OperationCanceledException ex)
       {
         ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;

--- a/src/KSail/Commands/Stop/KSailStopCommand.cs
+++ b/src/KSail/Commands/Stop/KSailStopCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using KSail.Commands.Stop.Handlers;
 using KSail.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.Stop;
 
@@ -32,13 +33,18 @@ sealed class KSailStopCommand : Command
           throw new KSailException("Cluster could not be stopped");
         }
       }
-      catch (OperationCanceledException)
+      catch (YamlException ex)
       {
+        ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;
       }
       catch (KSailException ex)
       {
         ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+      catch (OperationCanceledException)
+      {
         context.ExitCode = 1;
       }
     });

--- a/src/KSail/Commands/Update/KSailUpdateCommand.cs
+++ b/src/KSail/Commands/Update/KSailUpdateCommand.cs
@@ -3,6 +3,7 @@ using Devantler.FluxCLI;
 using KSail.Commands.Update.Handlers;
 using KSail.Options;
 using KSail.Utils;
+using YamlDotNet.Core;
 
 namespace KSail.Commands.Update;
 
@@ -34,12 +35,17 @@ sealed class KSailUpdateCommand : Command
         var handler = new KSailUpdateCommandHandler(config);
         context.ExitCode = await handler.HandleAsync(context.GetCancellationToken()).ConfigureAwait(false) ? 0 : 1;
       }
-      catch (OperationCanceledException ex)
+      catch (YamlException ex)
       {
         ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;
       }
       catch (FluxException ex)
+      {
+        ExceptionHandler.HandleException(ex);
+        context.ExitCode = 1;
+      }
+      catch (OperationCanceledException ex)
       {
         ExceptionHandler.HandleException(ex);
         context.ExitCode = 1;


### PR DESCRIPTION
Introduce handling for YamlException in command execution to enhance error reporting for invalid ksail configuration files. This change aims to provide clearer feedback when configuration issues arise.