### PR TITLE
Add containerd config patch for mirror registries

### DIFF
--- a/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
+++ b/src/KSail/Commands/Init/Generators/SubGenerators/DistributionConfigFileGenerator.cs
@@ -41,7 +41,13 @@ class DistributionConfigFileGenerator
     Console.WriteLine($"✚ generating '{outputPath}'");
     var kindConfig = new KindConfig
     {
-      Name = config.Metadata.Name
+      Name = config.Metadata.Name,
+      ContainerdConfigPatches = config.Spec.Project.MirrorRegistries ? [
+        """
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          config_path = "/etc/containerd/certs.d"
+        """
+      ] : null
     };
 
     await _kindConfigKubernetesGenerator.GenerateAsync(kindConfig, outputPath, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/KSail/KSail.csproj
+++ b/src/KSail/KSail.csproj
@@ -22,14 +22,14 @@
 
   <ItemGroup>
     <PackageReference Include="Devantler.ContainerEngineProvisioner.Docker" Version="1.0.10" />
-    <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.1.56" />
-    <PackageReference Include="Devantler.KubernetesGenerator.CertManager" Version="1.2.5" />
-    <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.2.5" />
-    <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.2.5" />
-    <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.2.5" />
+    <PackageReference Include="Devantler.SecretManager.SOPS.LocalAge" Version="1.1.57" />
+    <PackageReference Include="Devantler.KubernetesGenerator.CertManager" Version="1.2.6" />
+    <PackageReference Include="Devantler.KubernetesGenerator.Flux" Version="1.2.6" />
+    <PackageReference Include="Devantler.KubernetesGenerator.K3d" Version="1.2.6" />
+    <PackageReference Include="Devantler.KubernetesGenerator.Kind" Version="1.2.6" />
     <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.K3d" Version="1.2.7" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.2.6" />
-    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.2.6" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.Cluster.Kind" Version="1.2.7" />
+    <PackageReference Include="Devantler.KubernetesProvisioner.GitOps.Flux" Version="1.2.7" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.Schemas" Version="1.0.24" />
     <PackageReference Include="Devantler.KubernetesValidator.ClientSide.YamlSyntax" Version="1.0.24" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-advanced-multi/kind-config.yaml.verified.yaml
@@ -2,7 +2,3 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: cluster1
-containerdConfigPatches:
-- >-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests/Commands/Init/mixed-simple-multi/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/mixed-simple-multi/kind-config.yaml.verified.yaml
@@ -2,7 +2,3 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: cluster1
-containerdConfigPatches:
-- >-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests/Commands/Init/native-advanced-existing/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced-existing/kind-config.yaml.verified.yaml
@@ -2,7 +2,3 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: ksail-advanced-native
-containerdConfigPatches:
-- >-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests/Commands/Init/native-advanced/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-advanced/kind-config.yaml.verified.yaml
@@ -2,7 +2,3 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: ksail-advanced-native
-containerdConfigPatches:
-- >-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests/Commands/Init/native-simple-existing/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-simple-existing/kind-config.yaml.verified.yaml
@@ -2,7 +2,3 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: ksail-default
-containerdConfigPatches:
-- >-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"

--- a/tests/KSail.Tests/Commands/Init/native-simple/kind-config.yaml.verified.yaml
+++ b/tests/KSail.Tests/Commands/Init/native-simple/kind-config.yaml.verified.yaml
@@ -2,7 +2,3 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: ksail-default
-containerdConfigPatches:
-- >-
-  [plugins."io.containerd.grpc.v1.cri".registry]
-    config_path = "/etc/containerd/certs.d"


### PR DESCRIPTION
Introduce a configuration patch for containerd when mirror registries are enabled, enhancing the cluster setup process. Update package references to their latest versions.