### PR TITLE
Add `ksail secrets export` command for exporting keys to a file

### DIFF
--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsExportCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsExportCommandHandler.cs
@@ -1,0 +1,18 @@
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+class KSailSecretsExportCommandHandler(string publicKey, string outputPath, ISecretManager<AgeKey> secretManager)
+{
+  readonly string _publicKey = publicKey;
+  readonly string _outputPath = outputPath;
+  readonly ISecretManager<AgeKey> _secretManager = secretManager;
+
+  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    Console.WriteLine($"► exporting '{_publicKey}' to '{_outputPath}'");
+    var key = await _secretManager.GetKeyAsync(_publicKey, cancellationToken).ConfigureAwait(false);
+    File.WriteAllText(_outputPath, key.ToString());
+    Console.WriteLine("✔ key exported successfully");
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Secrets/KSailSecretsCommand.cs
+++ b/src/KSail/Commands/Secrets/KSailSecretsCommand.cs
@@ -20,5 +20,6 @@ sealed class KSailSecretsCommand : Command
     AddCommand(new KSailSecretsGenerateCommand());
     AddCommand(new KSailSecretsDeleteCommand());
     AddCommand(new KSailSecretsListCommand());
+    AddCommand(new KSailSecretsExportCommand());
   }
 }

--- a/tests/KSail.Tests/Commands/Secrets/KSailSecretsCommandTests.KSailSecretsHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/KSailSecretsCommandTests.KSailSecretsHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -9,7 +9,8 @@ Options:
   -?, -h, --help  Show help and usage information
 
 Commands:
-  gen               Generate a new encryption key
-  del <public-key>  Delete an existing encryption key
-  list              List keys
+  gen                  Generate a new encryption key
+  del <public-key>     Delete an existing encryption key
+  list                 List keys
+  export <public-key>  Export a key to a file
 


### PR DESCRIPTION
Introduce a new command to export keys to a specified file, enhancing the functionality of the secrets management system.

- Closes #442 