### PR TITLE
Add `ksail secrets import` command and enhance export validation

### DIFF
--- a/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
+++ b/src/KSail/Commands/Secrets/Handlers/KSailSecretsImportCommandHandler.cs
@@ -1,0 +1,18 @@
+using Devantler.Keys.Age;
+using Devantler.SecretManager.Core;
+
+class KSailSecretsImportCommandHandler(string inputPath, ISecretManager<AgeKey> secretManager)
+{
+  readonly string _inputPath = inputPath;
+  readonly ISecretManager<AgeKey> _secretManager = secretManager;
+
+  internal async Task<int> HandleAsync(CancellationToken cancellationToken)
+  {
+    Console.WriteLine($"► importing key from '{_inputPath}'");
+    string key = File.ReadAllText(_inputPath);
+    var ageKey = new AgeKey(key);
+    _ = await _secretManager.ImportKeyAsync(ageKey, cancellationToken).ConfigureAwait(false);
+    Console.WriteLine("✔ key imported successfully");
+    return 0;
+  }
+}

--- a/src/KSail/Commands/Secrets/KSailSecretsCommand.cs
+++ b/src/KSail/Commands/Secrets/KSailSecretsCommand.cs
@@ -20,6 +20,7 @@ sealed class KSailSecretsCommand : Command
     AddCommand(new KSailSecretsGenerateCommand());
     AddCommand(new KSailSecretsDeleteCommand());
     AddCommand(new KSailSecretsListCommand());
+    AddCommand(new KSailSecretsImportCommand());
     AddCommand(new KSailSecretsExportCommand());
   }
 }

--- a/tests/KSail.Tests/Commands/Secrets/KSailSecretsCommandTests.KSailSecretsHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
+++ b/tests/KSail.Tests/Commands/Secrets/KSailSecretsCommandTests.KSailSecretsHelp_SucceedsAndPrintsIntroductionAndHelp.verified.txt
@@ -12,5 +12,6 @@ Commands:
   gen                  Generate a new encryption key
   del <public-key>     Delete an existing encryption key
   list                 List keys
+  import               Import a key from a file
   export <public-key>  Export a key to a file
 


### PR DESCRIPTION
Introduce a new command for importing keys from a file and improve validation for the export command to ensure required options are provided.

- Closes #441 